### PR TITLE
Prefix environment variables with "TWITTER_" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Twitter API client for Clojure, using [`aleph`](https://github.com/ztellman/alep
 `twttr` is on [Clojars](https://clojars.org/twttr):
 
 ```edn
-[twttr "3.2.0"]
+[twttr "3.2.2"]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Twitter API client for Clojure, using [`aleph`](https://github.com/ztellman/alep
 `twttr` is on [Clojars](https://clojars.org/twttr):
 
 ```edn
-[twttr "3.2.2"]
+[twttr "3.2.3"]
 ```
 
 
@@ -31,7 +31,8 @@ Twitter API client for Clojure, using [`aleph`](https://github.com/ztellman/alep
             [twttr.auth :refer [env->UserCredentials]]))
 
 ; read credentials from environment variables, namely:
-; CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, and ACCESS_TOKEN_SECRET
+; TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET,
+; TWITTER_ACCESS_TOKEN and TWITTER_ACCESS_TOKEN_SECRET
 (def creds (env->UserCredentials))
 
 ; the "https://api.twitter.com/1.1/users/show.json" Resource URL
@@ -64,10 +65,10 @@ Twitter API client for Clojure, using [`aleph`](https://github.com/ztellman/alep
 The tests require that credentials be provided via environment variables with the following names:
 
 ```sh
-export CONSUMER_KEY=l4VAFAKEFAKEFAKEpy7R7
-export CONSUMER_SECRET=dVnTimJtFAKEFAKEFAKEFAKEFAKEFAKEBVYnO91BR1G
-export ACCESS_TOKEN=195648015-OIHb87zuFAKEFAKEFAKEFAKEFAKEFAKEb5aLUMYo
-export ACCESS_TOKEN_SECRET=jsVg1HFAKEFAKEFAKEFAKEFAKEFAKE4yfOLC5cXA9fcXr
+export TWITTER_CONSUMER_KEY=l4VAFAKEFAKEFAKEpy7R7
+export TWITTER_CONSUMER_SECRET=dVnTimJtFAKEFAKEFAKEFAKEFAKEFAKEBVYnO91BR1G
+export TWITTER_ACCESS_TOKEN=195648015-OIHb87zuFAKEFAKEFAKEFAKEFAKEFAKEb5aLUMYo
+export TWITTER_ACCESS_TOKEN_SECRET=jsVg1HFAKEFAKEFAKEFAKEFAKEFAKE4yfOLC5cXA9fcXr
 ```
 
 Then run `lein test`, which can take a minute since many of the tests involve calling the Twitter API and waiting for an appropriate response. If all tests completed successfully, the test output will end with a message like:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject twttr "3.2.2"
+(defproject twttr "3.2.3"
   :description "Twitter API client supporting REST, streaming, and OAuth"
   :url "https://github.com/chbrown/twttr"
   :license {:name "Eclipse Public License"

--- a/src/twttr/auth.clj
+++ b/src/twttr/auth.clj
@@ -54,10 +54,10 @@
 
 (defn env->AppCredentials
   "Create an AppCredentials instance from environment variables, defaulting to
-  CONSUMER_KEY and CONSUMER_SECRET"
+  TWITTER_CONSUMER_KEY and TWITTER_CONSUMER_SECRET"
   ([]
-   (env->AppCredentials {:consumer-key    "CONSUMER_KEY"
-                         :consumer-secret "CONSUMER_SECRET"}))
+   (env->AppCredentials {:consumer-key    "TWITTER_CONSUMER_KEY"
+                         :consumer-secret "TWITTER_CONSUMER_SECRET"}))
   ([env-mapping]
    (map->AppCredentials (map-values #(System/getenv %) env-mapping))))
 
@@ -78,12 +78,13 @@
 
 (defn env->UserCredentials
   "Create a UserCredentials instance from environment variables, defaulting to
-  CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, and ACCESS_TOKEN_SECRET"
+  TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET, TWITTER_ACCESS_TOKEN and
+  TWITTER_ACCESS_TOKEN_SECRET."
   ([]
-   (env->UserCredentials {:consumer-key      "CONSUMER_KEY"
-                          :consumer-secret   "CONSUMER_SECRET"
-                          :user-token        "ACCESS_TOKEN"
-                          :user-token-secret "ACCESS_TOKEN_SECRET"}))
+   (env->UserCredentials {:consumer-key      "TWITTER_CONSUMER_KEY"
+                          :consumer-secret   "TWITTER_CONSUMER_SECRET"
+                          :user-token        "TWITTER_ACCESS_TOKEN"
+                          :user-token-secret "TWITTER_ACCESS_TOKEN_SECRET"}))
   ([env-mapping]
    (map->UserCredentials (map-values #(System/getenv %) env-mapping))))
 


### PR DESCRIPTION
I find ACCESS_TOKEN may conflict with environment variables for other applications/services.