### PR TITLE
add example of generating credentials from standard map

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Twitter API client for Clojure, using [`aleph`](https://github.com/ztellman/alep
 ; CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, and ACCESS_TOKEN_SECRET
 (def creds (env->UserCredentials))
 
+; or read credentials from map
+(def creds (twttr.auth/map->AppCredentials {:consumer-key    "xxx"
+                                            :consumer-secret "yyy"))
+
 ; the "https://api.twitter.com/1.1/users/show.json" Resource URL
 ; becomes the "users-show" function
 (api/users-show creds :params {:screen_name "jack"})


### PR DESCRIPTION
Thank you for this wonderful library!

I didn't want to set environment variables, instead wanting to generate credentials from inside REPL.  Enclosed is a small addition to README.md that shows an example that generates credentials from a standard map.  I think other people might find this valuable?