### PR TITLE
upload server fix

### DIFF
--- a/resources/endpoints.edn
+++ b/resources/endpoints.edn
@@ -177,9 +177,9 @@
 
  ;; Upload media
  ;; https://developer.twitter.com/en/docs/media/upload-media/api-reference
- {:path "/media/upload"          :request-method :post}
+ {:server-name "upload.twitter.com" :path "/media/upload"          :request-method :post}
  ; {:path "/media/upload"          :request-method :get}
- {:path "/media/metadata/create" :request-method :post}
+ {:server-name "upload.twitter.com" :path "/media/metadata/create" :request-method :post}
 
  ;; Trends
 


### PR DESCRIPTION
This only fixes the target server (which was wrong and resulted in 404s).

Uploading media will still not work / is not documented to work because its unclear how to send the image.

I still get "unrecognized media type" for byte arrays, files and input streams so I'm not sure how to actually upload media using this library.